### PR TITLE
Handle IPAM-only host deletion

### DIFF
--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -821,7 +821,7 @@ class WapiModule(WapiBase):
                 if (ib_obj_type == NIOS_HOST_RECORD):
                     # to check only by old_name if dns bypassing is set
                     if not obj_filter['configure_for_dns']:
-                        test_obj_filter = dict([('name', old_name), ('configure_for_dns', False)])
+                        test_obj_filter = dict([('name', old_name)])
                     else:
                         test_obj_filter = dict([('name', old_name), ('view', obj_filter['view'])])
                 # if there are multiple records with the same name and different ip
@@ -844,6 +844,8 @@ class WapiModule(WapiBase):
                     test_obj_filter = dict([('name', old_name)])
                 # get the object reference
                 ib_obj = self.get_object(ib_obj_type, test_obj_filter, return_fields=return_fields)
+                if obj_filter.get('configure_for_dns') is False and ib_obj:
+                    ib_obj = [obj for obj in ib_obj if obj.get('configure_for_dns') is False]
                 if ib_obj:
                     obj_filter['name'] = new_name
                 elif old_ipv4addr_exists and (len(ib_obj) == 0):
@@ -858,7 +860,7 @@ class WapiModule(WapiBase):
                 name = obj_filter['name']
                 # to check only by name if dns bypassing is set
                 if not obj_filter['configure_for_dns']:
-                    test_obj_filter = dict([('name', name), ('configure_for_dns', False)])
+                    test_obj_filter = dict([('name', name)])
                 else:
                     test_obj_filter = dict([('name', name), ('view', obj_filter['view'])])
             elif (ib_obj_type == NIOS_IPV4_FIXED_ADDRESS and 'mac' in obj_filter):
@@ -927,6 +929,8 @@ class WapiModule(WapiBase):
                 return_fields.extend(ipv6addrs_return)
 
             ib_obj = self.get_object(ib_obj_type, test_obj_filter.copy(), return_fields=return_fields)
+            if ib_obj_type == NIOS_HOST_RECORD and obj_filter.get('configure_for_dns') is False and ib_obj:
+                ib_obj = [obj for obj in ib_obj if obj.get('configure_for_dns') is False]
 
             # prevents creation of a new A record with 'new_ipv4addr' when A record with a particular 'old_ipv4addr' is not found
             if old_ipv4addr_exists and (ib_obj is None or len(ib_obj) == 0):

--- a/tests/unit/plugins/modules/test_nios_host_record.py
+++ b/tests/unit/plugins/modules/test_nios_host_record.py
@@ -102,6 +102,42 @@ class TestNiosHostRecordModule(TestNiosModule):
         self.assertTrue(res['changed'])
         wapi.delete_object.assert_called_once_with(ref)
 
+    def test_nios_host_record_remove_ipam_only(self):
+        self.module.params = {'provider': None, 'state': 'absent', 'name': 'ansible',
+                              'comment': None, 'extattrs': None, 'configure_for_dns': False}
+
+        dns_ref = "record:host/ZG5zLm5ldHdvcmtfdmlldyQw:ansible/true"
+        ipam_ref = "record:host/ZG5zLm5ldHdvcmtfdmlldyQw:ansible/false"
+
+        test_object = [
+            {
+                "comment": "dns host",
+                "_ref": dns_ref,
+                "name": "ansible",
+                "configure_for_dns": True,
+                "extattrs": {}
+            },
+            {
+                "comment": "ipam host",
+                "_ref": ipam_ref,
+                "name": "ansible",
+                "configure_for_dns": False,
+                "extattrs": {}
+            }
+        ]
+
+        test_spec = {
+            "name": {"ib_req": True},
+            "comment": {},
+            "extattrs": {},
+            "configure_for_dns": {"ib_req": True}
+        }
+
+        wapi = self._get_wapi(test_object)
+        res = wapi.run(api.NIOS_HOST_RECORD, test_spec)
+        self.assertTrue(res['changed'])
+        wapi.delete_object.assert_called_once_with(ipam_ref)
+
     def test_nios_host_record_update_comment(self):
         self.module.params = {'provider': None, 'state': 'present', 'name': 'default',
                               'comment': 'updated comment', 'extattrs': None}


### PR DESCRIPTION
## Summary
- filter host record lookup results by `configure_for_dns` after query
- add test ensuring IPAM-only hosts are deleted correctly

## Testing
- `PYTHONPATH=/tmp pytest tests/unit/plugins/modules/test_nios_host_record.py -q`
- `PYTHONPATH=/tmp pytest tests/unit/plugins/module_utils/test_api.py -q`
