### PR TITLE
Fix host record selection for duplicate IPv4

### DIFF
--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -375,27 +375,32 @@ class WapiModule(WapiBase):
         if not proposed_object.get('configure_for_dns') and proposed_object.get('view') == 'default' \
                 and ib_obj_type == NIOS_HOST_RECORD:
             del proposed_object['view']
+        ref = None
         if ib_obj_ref:
             if len(ib_obj_ref) > 1:
                 for each in ib_obj_ref:
                     # To check for existing A_record with same name with input A_record by IP
                     if each.get('ipv4addr') and each.get('ipv4addr') == proposed_object.get('ipv4addr'):
                         current_object = each
+                        ref = each.get('_ref')
                         break
                     # To check for existing Host_record with same name with input Host_record by IP
                     elif each.get('ipv4addrs') and each.get('ipv4addrs')[0].get('ipv4addr') \
                             == proposed_object.get('ipv4addrs')[0].get('ipv4addr'):
                         current_object = each
+                        ref = each.get('_ref')
+                        break
                     # Else set the current_object with input value
                     else:
                         current_object = obj_filter
                         ref = None
             else:
                 current_object = ib_obj_ref[0]
+                ref = current_object.get('_ref')
             if 'extattrs' in current_object:
                 current_object['extattrs'] = flatten_extattrs(current_object['extattrs'])
-            if current_object.get('_ref'):
-                ref = current_object.pop('_ref')
+            if ref:
+                current_object.pop('_ref', None)
         else:
             current_object = obj_filter
             ref = None

--- a/tests/unit/plugins/modules/test_nios_host_record.py
+++ b/tests/unit/plugins/modules/test_nios_host_record.py
@@ -193,3 +193,53 @@ class TestNiosHostRecordModule(TestNiosModule):
         wapi.update_object.assert_called_once_with(
             ref, {'comment': 'comment', 'name': 'default'}
         )
+
+    def test_nios_host_record_duplicate_ipv4(self):
+        self.module.params = {
+            'provider': None,
+            'state': 'present',
+            'name': 'ansible',
+            'comment': 'updated comment',
+            'extattrs': None,
+            'ipv4addrs': [{'ipv4addr': '192.168.1.2'}],
+        }
+
+        ref_match = "record:host/ZG5zLm5ldHdvcmtfdmlldyQw:ansible1/true"
+        ref_other = "record:host/ZG5zLm5ldHdvcmtfdmlldyQw:ansible2/true"
+
+        test_object = [
+            {
+                "comment": "old comment",
+                "_ref": ref_match,
+                "name": "ansible",
+                "ipv4addrs": [{"ipv4addr": "192.168.1.2"}],
+                "extattrs": {},
+            },
+            {
+                "comment": "other comment",
+                "_ref": ref_other,
+                "name": "ansible",
+                "ipv4addrs": [{"ipv4addr": "192.168.1.3"}],
+                "extattrs": {},
+            },
+        ]
+
+        test_spec = {
+            "name": {"ib_req": True},
+            "comment": {},
+            "extattrs": {},
+            "ipv4addrs": {},
+        }
+
+        wapi = self._get_wapi(test_object)
+        res = wapi.run('testobject', test_spec)
+
+        self.assertTrue(res['changed'])
+        wapi.update_object.assert_called_once_with(
+            ref_match,
+            {
+                'comment': 'updated comment',
+                'name': 'ansible',
+                'ipv4addrs': [{'ipv4addr': '192.168.1.2'}],
+            },
+        )


### PR DESCRIPTION
## Summary
- stop iterating once matching host record IPv4 is found
- track `_ref` for matched objects and initialize it upfront
- test duplicate hostnames differentiated by IPv4 address

## Testing
- `PYTHONPATH=$PWD pytest tests/unit/plugins/modules/test_nios_host_record.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0b3dafeb8832ca952c1a2fe075d16